### PR TITLE
멱등성 체크 기능 추가

### DIFF
--- a/.testcontainers.properties
+++ b/.testcontainers.properties
@@ -1,0 +1,1 @@
+testcontainers.reuse.enable=true

--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,15 @@ dependencies {
 
     //Swagger - API Documentation
     //implementation 'io.springfox:springfox-swagger-ui:2.9.2'
+
+    //Test Container dependency
+    testImplementation "org.testcontainers:testcontainers:1.20.4"
+    testImplementation "org.junit.jupiter:junit-jupiter:5.8.1"
+    testImplementation "org.testcontainers:junit-jupiter:1.20.4"
+
+    testImplementation "org.testcontainers:mysql:1.20.4"
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/comatching/comatching3/exception/GlobalExceptionHandler.java
+++ b/src/main/java/comatching/comatching3/exception/GlobalExceptionHandler.java
@@ -1,9 +1,12 @@
 package comatching.comatching3.exception;
 
+import comatching.comatching3.util.Idempotent.Exception.IdempotentException;
 import comatching.comatching3.util.Response;
 import comatching.comatching3.util.ResponseCode;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -46,5 +49,10 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(TossPaymentException.class)
     public Response<TossPaymentExceptionDto> handleTossPaymentException(TossPaymentException ex) {
         return new Response<>(ex.getTossPaymentExceptionDto());
+    }
+
+    @ExceptionHandler({IdempotentException.class})
+    public Response<ResponseCode> handelIdempotentException(IdempotentException ex){
+        return new Response<>(ex.getResponseCode());
     }
 }

--- a/src/main/java/comatching/comatching3/history/entity/MatchingHistory.java
+++ b/src/main/java/comatching/comatching3/history/entity/MatchingHistory.java
@@ -2,11 +2,11 @@ package comatching.comatching3.history.entity;
 
 import java.util.List;
 
-import comatching.comatching3.match.dto.messageQueue.MatchRequestMsg;
+import comatching.comatching3.matching.dto.messageQueue.MatchRequestMsg;
 import comatching.comatching3.users.entity.Users;
 import comatching.comatching3.users.enums.HobbyEnum;
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
 import comatching.comatching3.util.BaseEntity;
 import comatching.comatching3.util.HobbyListConverter;
 import jakarta.persistence.Column;

--- a/src/main/java/comatching/comatching3/matching/controller/MatchAdminController.java
+++ b/src/main/java/comatching/comatching3/matching/controller/MatchAdminController.java
@@ -1,20 +1,16 @@
-package comatching.comatching3.match.controller;
+package comatching.comatching3.matching.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import comatching.comatching3.match.dto.request.AdminMatchReq;
-import comatching.comatching3.match.dto.request.CodeCheckReq;
-import comatching.comatching3.match.dto.request.DeleteCsvReq;
-import comatching.comatching3.match.dto.request.RecoverReq;
-import comatching.comatching3.match.dto.response.CodeCheckRes;
-import comatching.comatching3.match.dto.response.MatchRes;
-import comatching.comatching3.match.service.AuthCodeService;
-import comatching.comatching3.match.service.MatchService;
-import comatching.comatching3.users.dto.UserFeatureReq;
+import comatching.comatching3.matching.dto.request.AdminMatchReq;
+import comatching.comatching3.matching.dto.request.CodeCheckReq;
+import comatching.comatching3.matching.dto.response.CodeCheckRes;
+import comatching.comatching3.matching.dto.response.MatchRes;
+import comatching.comatching3.matching.service.AuthCodeService;
+import comatching.comatching3.matching.service.MatchService;
 import comatching.comatching3.util.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/comatching/comatching3/matching/controller/MatchUserController.java
+++ b/src/main/java/comatching/comatching3/matching/controller/MatchUserController.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.controller;
+package comatching.comatching3.matching.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -6,11 +6,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import comatching.comatching3.match.dto.request.MatchReq;
-import comatching.comatching3.match.dto.response.MatchRes;
-import comatching.comatching3.match.dto.response.RequestCodeRes;
-import comatching.comatching3.match.service.AuthCodeService;
-import comatching.comatching3.match.service.MatchService;
+import comatching.comatching3.matching.dto.request.MatchReq;
+import comatching.comatching3.matching.dto.response.MatchRes;
+import comatching.comatching3.matching.dto.response.RequestCodeRes;
+import comatching.comatching3.matching.service.AuthCodeService;
+import comatching.comatching3.matching.service.MatchService;
 import comatching.comatching3.util.Response;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/comatching/comatching3/matching/dto/cache/CodeCheckInfo.java
+++ b/src/main/java/comatching/comatching3/matching/dto/cache/CodeCheckInfo.java
@@ -1,6 +1,6 @@
-package comatching.comatching3.match.dto.cache;
+package comatching.comatching3.matching.dto.cache;
 
-import comatching.comatching3.match.enums.CheckStatus;
+import comatching.comatching3.matching.enums.CheckStatus;
 import lombok.Builder;
 import lombok.Getter;
 

--- a/src/main/java/comatching/comatching3/matching/dto/messageQueue/MatchRequestMsg.java
+++ b/src/main/java/comatching/comatching3/matching/dto/messageQueue/MatchRequestMsg.java
@@ -1,12 +1,12 @@
-package comatching.comatching3.match.dto.messageQueue;
+package comatching.comatching3.matching.dto.messageQueue;
 
 import java.util.List;
 
 import comatching.comatching3.history.entity.MatchingHistory;
-import comatching.comatching3.match.dto.request.AdminMatchReq;
-import comatching.comatching3.match.dto.request.MatchReq;
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
+import comatching.comatching3.matching.dto.request.AdminMatchReq;
+import comatching.comatching3.matching.dto.request.MatchReq;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
 import comatching.comatching3.users.entity.UserAiFeature;
 import comatching.comatching3.users.enums.HobbyEnum;
 import comatching.comatching3.util.UUIDUtil;

--- a/src/main/java/comatching/comatching3/matching/dto/messageQueue/MatchResponseMsg.java
+++ b/src/main/java/comatching/comatching3/matching/dto/messageQueue/MatchResponseMsg.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.messageQueue;
+package comatching.comatching3.matching.dto.messageQueue;
 
 import lombok.Data;
 import lombok.NoArgsConstructor;

--- a/src/main/java/comatching/comatching3/matching/dto/request/AdminMatchReq.java
+++ b/src/main/java/comatching/comatching3/matching/dto/request/AdminMatchReq.java
@@ -1,9 +1,9 @@
-package comatching.comatching3.match.dto.request;
+package comatching.comatching3.matching.dto.request;
 
 import java.util.List;
 
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
 import comatching.comatching3.users.enums.HobbyEnum;
 import comatching.comatching3.util.validation.ValidEnum;
 import jakarta.validation.constraints.Pattern;

--- a/src/main/java/comatching/comatching3/matching/dto/request/CodeCheckReq.java
+++ b/src/main/java/comatching/comatching3/matching/dto/request/CodeCheckReq.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.request;
+package comatching.comatching3.matching.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/comatching/comatching3/matching/dto/request/DeleteCsvReq.java
+++ b/src/main/java/comatching/comatching3/matching/dto/request/DeleteCsvReq.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.request;
+package comatching.comatching3.matching.dto.request;
 
 import lombok.Data;
 

--- a/src/main/java/comatching/comatching3/matching/dto/request/MatchReq.java
+++ b/src/main/java/comatching/comatching3/matching/dto/request/MatchReq.java
@@ -1,9 +1,9 @@
-package comatching.comatching3.match.dto.request;
+package comatching.comatching3.matching.dto.request;
 
 import java.util.List;
 
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
 import comatching.comatching3.users.enums.HobbyEnum;
 import comatching.comatching3.util.validation.ValidEnum;
 import lombok.AllArgsConstructor;

--- a/src/main/java/comatching/comatching3/matching/dto/request/RecoverReq.java
+++ b/src/main/java/comatching/comatching3/matching/dto/request/RecoverReq.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.request;
+package comatching.comatching3.matching.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/comatching/comatching3/matching/dto/response/CodeCheckRes.java
+++ b/src/main/java/comatching/comatching3/matching/dto/response/CodeCheckRes.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.response;
+package comatching.comatching3.matching.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/comatching/comatching3/matching/dto/response/MatchRes.java
+++ b/src/main/java/comatching/comatching3/matching/dto/response/MatchRes.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.response;
+package comatching.comatching3.matching.dto.response;
 
 import java.util.List;
 
@@ -6,7 +6,6 @@ import comatching.comatching3.users.entity.Hobby;
 import comatching.comatching3.users.entity.Users;
 import comatching.comatching3.users.enums.ContactFrequency;
 import comatching.comatching3.users.enums.Gender;
-import comatching.comatching3.users.enums.HobbyEnum;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/comatching/comatching3/matching/dto/response/RequestCodeRes.java
+++ b/src/main/java/comatching/comatching3/matching/dto/response/RequestCodeRes.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.dto.response;
+package comatching.comatching3.matching.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/comatching/comatching3/matching/enums/AgeOption.java
+++ b/src/main/java/comatching/comatching3/matching/enums/AgeOption.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.enums;
+package comatching.comatching3.matching.enums;
 
 public enum AgeOption {
 	YOUNGER,

--- a/src/main/java/comatching/comatching3/matching/enums/CheckStatus.java
+++ b/src/main/java/comatching/comatching3/matching/enums/CheckStatus.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.enums;
+package comatching.comatching3.matching.enums;
 
 public enum CheckStatus {
 	REQUESTED,

--- a/src/main/java/comatching/comatching3/matching/enums/ContactFrequencyOption.java
+++ b/src/main/java/comatching/comatching3/matching/enums/ContactFrequencyOption.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match.enums;
+package comatching.comatching3.matching.enums;
 
 public enum ContactFrequencyOption {
 	FREQUENT,

--- a/src/main/java/comatching/comatching3/matching/service/AuthCodeService.java
+++ b/src/main/java/comatching/comatching3/matching/service/AuthCodeService.java
@@ -1,15 +1,15 @@
-package comatching.comatching3.match.service;
+package comatching.comatching3.matching.service;
 
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import comatching.comatching3.exception.BusinessException;
-import comatching.comatching3.match.dto.cache.CodeCheckInfo;
-import comatching.comatching3.match.dto.request.CodeCheckReq;
-import comatching.comatching3.match.dto.response.CodeCheckRes;
-import comatching.comatching3.match.dto.response.RequestCodeRes;
-import comatching.comatching3.match.enums.CheckStatus;
+import comatching.comatching3.matching.dto.cache.CodeCheckInfo;
+import comatching.comatching3.matching.dto.request.CodeCheckReq;
+import comatching.comatching3.matching.dto.response.CodeCheckRes;
+import comatching.comatching3.matching.dto.response.RequestCodeRes;
+import comatching.comatching3.matching.enums.CheckStatus;
 import comatching.comatching3.users.entity.Users;
 import comatching.comatching3.users.repository.UsersRepository;
 import comatching.comatching3.util.RedisUtil;

--- a/src/main/java/comatching/comatching3/matching/service/MatchService.java
+++ b/src/main/java/comatching/comatching3/matching/service/MatchService.java
@@ -1,6 +1,6 @@
-package comatching.comatching3.match.service;
+package comatching.comatching3.matching.service;
 
-import java.util.ArrayList;
+import comatching.comatching3.util.Idempotent.Idempotent;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -13,22 +13,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import comatching.comatching3.exception.BusinessException;
 import comatching.comatching3.history.entity.MatchingHistory;
 import comatching.comatching3.history.repository.MatchingHistoryRepository;
-import comatching.comatching3.match.dto.cache.CodeCheckInfo;
-import comatching.comatching3.match.dto.messageQueue.MatchRequestMsg;
-import comatching.comatching3.match.dto.messageQueue.MatchResponseMsg;
-import comatching.comatching3.match.dto.request.AdminMatchReq;
-import comatching.comatching3.match.dto.request.DeleteCsvReq;
-import comatching.comatching3.match.dto.request.MatchReq;
-import comatching.comatching3.match.dto.request.RecoverReq;
-import comatching.comatching3.match.dto.response.MatchRes;
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
-import comatching.comatching3.users.dto.UserFeatureReq;
-import comatching.comatching3.users.entity.Hobby;
-import comatching.comatching3.users.entity.UserAiFeature;
+import comatching.comatching3.matching.dto.cache.CodeCheckInfo;
+import comatching.comatching3.matching.dto.messageQueue.MatchRequestMsg;
+import comatching.comatching3.matching.dto.messageQueue.MatchResponseMsg;
+import comatching.comatching3.matching.dto.request.AdminMatchReq;
+import comatching.comatching3.matching.dto.request.MatchReq;
+import comatching.comatching3.matching.dto.response.MatchRes;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
 import comatching.comatching3.users.entity.Users;
-import comatching.comatching3.users.enums.ContactFrequency;
-import comatching.comatching3.users.enums.Gender;
 import comatching.comatching3.users.enums.HobbyEnum;
 import comatching.comatching3.users.enums.UserCrudType;
 import comatching.comatching3.users.repository.HobbyRepository;
@@ -64,6 +57,7 @@ public class MatchService {
 	 * @return 요청 성공시 GEN-001
 	 *
 	 */
+	@Idempotent
 	@Transactional
 	public MatchRes requestMatch(MatchReq matchReq){
 		String requestId = UUID.randomUUID().toString();

--- a/src/main/java/comatching/comatching3/util/Idempotent/CachingRequestFilter.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/CachingRequestFilter.java
@@ -16,18 +16,24 @@ import org.springframework.web.util.ContentCachingRequestWrapper;
 @Order(Integer.MIN_VALUE)
 public class CachingRequestFilter implements Filter {
 
+    /**
+     *
+     * POST 요청시에만 ContentCachingRequestWrapper에 request 저장
+     *
+     * @throws IOException
+     * @throws ServletException
+     */
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
 
-        // GET 요청이 아닌 경우에만 ContentCachingRequestWrapper 적용
         if (!"GET".equalsIgnoreCase(httpServletRequest.getMethod())) {
-            // ContentCachingRequestWrapper로 요청 래핑
+
             ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(httpServletRequest);
 
             filterChain.doFilter(wrappedRequest, response);
         }
-        // GET 요청인 경우 ContentCachingRequestWrapper 적용하지 않음
+
         else {
             filterChain.doFilter(request, response);
         }

--- a/src/main/java/comatching/comatching3/util/Idempotent/CachingRequestFilter.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/CachingRequestFilter.java
@@ -1,0 +1,35 @@
+package comatching.comatching3.util.Idempotent;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+
+@Component
+@Order(Integer.MIN_VALUE)
+public class CachingRequestFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        // GET 요청이 아닌 경우에만 ContentCachingRequestWrapper 적용
+        if (!"GET".equalsIgnoreCase(httpServletRequest.getMethod())) {
+            // ContentCachingRequestWrapper로 요청 래핑
+            ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(httpServletRequest);
+
+            filterChain.doFilter(wrappedRequest, response);
+        }
+        // GET 요청인 경우 ContentCachingRequestWrapper 적용하지 않음
+        else {
+            filterChain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/comatching/comatching3/util/Idempotent/Exception/IdempotentException.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/Exception/IdempotentException.java
@@ -1,0 +1,13 @@
+package comatching.comatching3.util.Idempotent.Exception;
+
+import comatching.comatching3.util.ResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class IdempotentException extends RuntimeException{
+
+    private final ResponseCode responseCode;
+}

--- a/src/main/java/comatching/comatching3/util/Idempotent/Idempotent.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/Idempotent.java
@@ -1,0 +1,12 @@
+package comatching.comatching3.util.Idempotent;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+    int expireTime() default 7;
+}

--- a/src/main/java/comatching/comatching3/util/Idempotent/IdempotentAspect.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/IdempotentAspect.java
@@ -1,7 +1,9 @@
 package comatching.comatching3.util.Idempotent;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import comatching.comatching3.util.Idempotent.Exception.IdempotentException;
 import comatching.comatching3.util.RedisUtil;
+import comatching.comatching3.util.ResponseCode;
 import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -79,11 +81,12 @@ public class IdempotentAspect {
         String originRequestValue = stringRedisTemplate.opsForValue().get(requestKey);
         log.info("[IdempotentAspect] ({}) 기존의 요청 데이터 :: {}", requestKey, originRequestValue);
 
+        //요청이 내용이 비어있지 않으면서 원래 요청이랑 같은 경우
         if (!requestValue.isBlank() && !requestValue.equals(originRequestValue))
-            log.info("exception");
-            //Todo: exception
+            throw new IdempotentException(ResponseCode.UNPROCESSABLE_ENTITY);
+
+        //요청이 같지 않은 경우
         else
-            log.info("exception");
-            //Todo: exception
+            throw new IdempotentException(ResponseCode.CONFLICT);
     }
 }

--- a/src/main/java/comatching/comatching3/util/Idempotent/IdempotentAspect.java
+++ b/src/main/java/comatching/comatching3/util/Idempotent/IdempotentAspect.java
@@ -1,0 +1,89 @@
+package comatching.comatching3.util.Idempotent;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import comatching.comatching3.util.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotentAspect {
+
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+
+    @Pointcut("@annotation(idempotent)")
+    public void pointCut(Idempotent idempotent){
+    }
+
+    @Before(value = "pointCut(idempotent)", argNames = "joinPoint, idempotent")
+    public void before(JoinPoint joinPoint, Idempotent idempotent) throws IOException{
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+
+        String requestKey = getRequestKey(request);
+        String requestValue = getRequestValue(request);
+
+        log.info("[IdempotentAspect] ({}) 요청 데이터 :: {}",  requestKey, requestValue);
+
+        int expireTime = idempotent.expireTime();
+
+        Boolean isPoss = stringRedisTemplate
+                .opsForValue()
+                .setIfAbsent(requestKey, requestValue, expireTime, TimeUnit.SECONDS);
+
+        if(Boolean.FALSE.equals(isPoss)){
+            handleRequestException(requestKey, requestValue);
+        }
+
+    }
+
+    private String getRequestKey(final HttpServletRequest request){
+        String token = request.getHeader("requestKey");
+
+        if(token == null)
+            throw new IllegalArgumentException();
+
+        return token;
+    }
+
+    private String getRequestValue(final HttpServletRequest request){
+        if(!"GET".equalsIgnoreCase(request.getMethod())){
+            ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+
+            return new String(cachingRequest.getContentAsByteArray(), StandardCharsets.UTF_8);
+        }
+
+        else{
+            return request.getQueryString();
+        }
+    }
+
+    private void handleRequestException(final String requestKey, final String requestValue) {
+
+        String originRequestValue = stringRedisTemplate.opsForValue().get(requestKey);
+        log.info("[IdempotentAspect] ({}) 기존의 요청 데이터 :: {}", requestKey, originRequestValue);
+
+        if (!requestValue.isBlank() && !requestValue.equals(originRequestValue))
+            log.info("exception");
+            //Todo: exception
+        else
+            log.info("exception");
+            //Todo: exception
+    }
+}

--- a/src/main/java/comatching/comatching3/util/RabbitMQ/MatchRabbitMQUtil.java
+++ b/src/main/java/comatching/comatching3/util/RabbitMQ/MatchRabbitMQUtil.java
@@ -8,8 +8,8 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 
 import comatching.comatching3.exception.BusinessException;
-import comatching.comatching3.match.dto.messageQueue.MatchRequestMsg;
-import comatching.comatching3.match.dto.messageQueue.MatchResponseMsg;
+import comatching.comatching3.matching.dto.messageQueue.MatchRequestMsg;
+import comatching.comatching3.matching.dto.messageQueue.MatchResponseMsg;
 import comatching.comatching3.util.ResponseCode;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/comatching/comatching3/util/ResponseCode.java
+++ b/src/main/java/comatching/comatching3/util/ResponseCode.java
@@ -52,7 +52,10 @@ public enum ResponseCode {
 
 	//Payment exception response
 	PAYMENT_FAIL(400, "PAY-001", HttpStatus.BAD_REQUEST, "Payment failed"),
-	;
+
+	//Idempotent exception response
+	UNPROCESSABLE_ENTITY(422, "IDP-001", HttpStatus.UNPROCESSABLE_ENTITY, "Unprocessable Entity"),
+	CONFLICT(409, "IDP-002", HttpStatus.CONFLICT, "Conflict");
 
 
 	private final Integer status;

--- a/src/test/java/comatching/comatching3/matching/MatchTest.java
+++ b/src/test/java/comatching/comatching3/matching/MatchTest.java
@@ -1,4 +1,4 @@
-package comatching.comatching3.match;
+package comatching.comatching3.matching;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -19,12 +19,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import comatching.comatching3.history.repository.MatchingHistoryRepository;
-import comatching.comatching3.match.dto.messageQueue.MatchResponseMsg;
-import comatching.comatching3.match.dto.request.MatchReq;
-import comatching.comatching3.match.dto.response.MatchRes;
-import comatching.comatching3.match.enums.AgeOption;
-import comatching.comatching3.match.enums.ContactFrequencyOption;
-import comatching.comatching3.match.service.MatchService;
+import comatching.comatching3.matching.dto.messageQueue.MatchResponseMsg;
+import comatching.comatching3.matching.dto.request.MatchReq;
+import comatching.comatching3.matching.dto.response.MatchRes;
+import comatching.comatching3.matching.enums.AgeOption;
+import comatching.comatching3.matching.enums.ContactFrequencyOption;
+import comatching.comatching3.matching.service.MatchService;
 import comatching.comatching3.users.entity.UserAiFeature;
 import comatching.comatching3.users.entity.Users;
 import comatching.comatching3.users.enums.HobbyEnum;

--- a/src/test/java/comatching/comatching3/testConfiguration/TestContainerConfigTest.java
+++ b/src/test/java/comatching/comatching3/testConfiguration/TestContainerConfigTest.java
@@ -1,0 +1,25 @@
+package comatching.comatching3.testConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@SpringBootTest
+public class TestContainerConfigTest extends TestContainers {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @Test
+    @DisplayName("Redis Test Container 동작 확인")
+    void testRedis() {
+        redisTemplate.opsForValue().set("key", "value");
+        String result = redisTemplate.opsForValue().get("key");
+
+        assertThat(result).isEqualTo("value");
+    }
+}

--- a/src/test/java/comatching/comatching3/testConfiguration/TestContainers.java
+++ b/src/test/java/comatching/comatching3/testConfiguration/TestContainers.java
@@ -1,0 +1,47 @@
+package comatching.comatching3.testConfiguration;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@Testcontainers
+abstract public class TestContainers {
+
+    private static final DockerImageName MYSQL_IMAGE_NAME = DockerImageName.parse("mysql:8");
+    private static final DockerImageName REDIS_IMAGE_NAME = DockerImageName.parse("redis:7");
+
+    @Container
+    private static final MySQLContainer<?> mySQLContainer = new MySQLContainer<>(MYSQL_IMAGE_NAME)
+            .withReuse(true);
+
+    @Container
+    private static final GenericContainer<?> redisContainer = new GenericContainer<>(REDIS_IMAGE_NAME)
+            .withExposedPorts(6379)
+            .withReuse(true);
+
+    @DynamicPropertySource
+    private static void dynamicProperties(DynamicPropertyRegistry registry) {
+
+        //✅ mysql
+        registry.add("spring.datasource.url", mySQLContainer::getJdbcUrl);
+        registry.add("spring.datasource.driver-class-name", mySQLContainer::getDriverClassName);
+        registry.add("spring.datasource.username", mySQLContainer::getUsername);
+        registry.add("spring.datasource.password", mySQLContainer::getPassword);
+
+        //auto-ddl
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "update");  // 또는 "none", "create-drop" 등
+
+        //✅ redis
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+    }
+
+}


### PR DESCRIPTION
### POST 요청에 대한 멱등성 검증 
 - Servlet filter에서 POST 요청시 `ContentCachingRequestWrapper`로 컨택스트 유지
 - Redis기반 Request key 저장
 - AOP 기반의 멱등성 검사 기능
 - Post 요청의 Service 레이어에서 `@Idempotent`어노테이션 적용시 멱등성 검증 가능

### 테스트 환경을 위한 TestContainer 도입
 - Redis, Mysql TestContainer 추가
 - 테스트 환경에서 원천 DB가 아닌 임시 환경을 통한 테스트 가능