### PR TITLE
Prod 환경 컨테이너 이름 설정

### DIFF
--- a/docker-compose.override.prod.yml
+++ b/docker-compose.override.prod.yml
@@ -2,6 +2,7 @@
 
 services:
   app:
+    container_name: prod-comatching-be-app
     ports:
       - "40010:8080"
       - "5672:5672"
@@ -9,12 +10,14 @@ services:
       - prod_app_logs:/app/logs
 
   mysql:
+    container_name: prod-mysql
     ports:
       - "40000:3306"
     volumes:
       - prod_mysql_data:/var/lib/mysql
 
   redis:
+    container_name: prod-redis
     ports:
       - "40001:6379"
     volumes:


### PR DESCRIPTION
## 변경사항
 - docker-compose `prod` 환경 override 파일에서 컨테이너 이름 설정