### PR TITLE
($Event) 이벤트 조회 추가 및 리팩터링

### DIFF
--- a/src/main/java/comatching/comatching3/event/controller/AdminEventController.java
+++ b/src/main/java/comatching/comatching3/event/controller/AdminEventController.java
@@ -1,7 +1,7 @@
 package comatching.comatching3.event.controller;
 
 import comatching.comatching3.event.dto.req.DiscountEventRegisterReq;
-import comatching.comatching3.event.dto.res.DiscountEventRes;
+import comatching.comatching3.event.dto.res.EventRes;
 import comatching.comatching3.event.service.AdminEventService;
 import comatching.comatching3.util.Response;
 import lombok.AllArgsConstructor;
@@ -40,7 +40,7 @@ public class AdminEventController {
      * @return
      */
     @GetMapping("/admin/event/inquiry")
-    public Response<List<DiscountEventRes>> inquiryEvent() {
+    public Response<List<EventRes>> inquiryEvent() {
         return Response.ok(adminEventService.inquiryEvent());
     }
 

--- a/src/main/java/comatching/comatching3/event/controller/InquiryStatus.java
+++ b/src/main/java/comatching/comatching3/event/controller/InquiryStatus.java
@@ -1,0 +1,5 @@
+package comatching.comatching3.event.controller;
+
+public enum InquiryStatus {
+    OPEN;
+}

--- a/src/main/java/comatching/comatching3/event/controller/UserEventController.java
+++ b/src/main/java/comatching/comatching3/event/controller/UserEventController.java
@@ -1,0 +1,44 @@
+package comatching.comatching3.event.controller;
+
+import comatching.comatching3.event.dto.res.EventRes;
+import comatching.comatching3.event.service.EventUserService;
+import comatching.comatching3.exception.BusinessException;
+import comatching.comatching3.util.Response;
+import comatching.comatching3.util.ResponseCode;
+import lombok.AllArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@AllArgsConstructor
+@RequestMapping("/auth/user")
+public class UserEventController {
+
+    private final EventUserService EventUserService;
+    private final EventUserService eventUserService;
+
+    /**
+     * 유저 이벤트 조회 리스트 컨트롤러
+     *
+     * @param status - open : 현재 진행중이거나 진행될 소속 학교의 event
+     * @return
+     */
+    @GetMapping("/events")
+    public Response<List<EventRes>> requestActivatedEvent(@RequestParam InquiryStatus status) {
+
+        List<EventRes> result = null;
+        if (status == InquiryStatus.OPEN) {
+            result = eventUserService.inquiryOpenEvent();
+        }
+
+        if (result == null) {
+            throw new BusinessException(ResponseCode.WRONG_EVENT_STATUS);
+        }
+
+        return Response.ok(result);
+    }
+}

--- a/src/main/java/comatching/comatching3/event/dto/res/DiscountEventRes.java
+++ b/src/main/java/comatching/comatching3/event/dto/res/DiscountEventRes.java
@@ -1,21 +1,22 @@
 package comatching.comatching3.event.dto.res;
 
 import comatching.comatching3.admin.enums.EventType;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.Data;
 
 import java.time.LocalDateTime;
 
 
-@Setter
-@Getter
-@NoArgsConstructor
-public class DiscountEventRes {
-    private Long eventId;
-    private LocalDateTime start;
-    private LocalDateTime end;
-    private EventType eventType;
+@Data
+public class DiscountEventRes extends EventRes {
     Integer discountRate;
 
+    public DiscountEventRes(Long eventId, LocalDateTime start, LocalDateTime end,
+                            EventType eventType, Boolean isActive, Integer discountRate) {
+        super(eventId, start, end, eventType, isActive);
+        this.discountRate = discountRate;
+    }
+
+    public DiscountEventRes() {
+        super();
+    }
 }

--- a/src/main/java/comatching/comatching3/event/dto/res/DiscountEventRes.java
+++ b/src/main/java/comatching/comatching3/event/dto/res/DiscountEventRes.java
@@ -1,6 +1,7 @@
 package comatching.comatching3.event.dto.res;
 
 import comatching.comatching3.admin.enums.EventType;
+import comatching.comatching3.event.entity.DiscountEvent;
 import lombok.Data;
 
 import java.time.LocalDateTime;
@@ -14,6 +15,11 @@ public class DiscountEventRes extends EventRes {
                             EventType eventType, Boolean isActive, Integer discountRate) {
         super(eventId, start, end, eventType, isActive);
         this.discountRate = discountRate;
+    }
+
+    public DiscountEventRes(DiscountEvent discountEvent) {
+        super(discountEvent.getId(), discountEvent.getStart(), discountEvent.getEnd(), discountEvent.toEventRes().getEventType(), discountEvent.getIsActivate());
+        this.discountRate = discountEvent.getDiscountRate();
     }
 
     public DiscountEventRes() {

--- a/src/main/java/comatching/comatching3/event/dto/res/EventRes.java
+++ b/src/main/java/comatching/comatching3/event/dto/res/EventRes.java
@@ -1,0 +1,19 @@
+package comatching.comatching3.event.dto.res;
+
+import comatching.comatching3.admin.enums.EventType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public abstract class EventRes {
+    protected Long eventId;
+    protected LocalDateTime start;
+    protected LocalDateTime end;
+    protected EventType eventType;
+    protected Boolean isActive;
+}

--- a/src/main/java/comatching/comatching3/event/entity/DiscountEvent.java
+++ b/src/main/java/comatching/comatching3/event/entity/DiscountEvent.java
@@ -1,6 +1,9 @@
 package comatching.comatching3.event.entity;
 
 import comatching.comatching3.admin.entity.University;
+import comatching.comatching3.admin.enums.EventType;
+import comatching.comatching3.event.dto.res.DiscountEventRes;
+import comatching.comatching3.event.dto.res.EventRes;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import lombok.AccessLevel;
@@ -18,10 +21,16 @@ public class DiscountEvent extends Event {
     private Integer discountRate;
 
     @Builder
-    public DiscountEvent(LocalDateTime start, LocalDateTime end, University university, Integer discountRate) {
+    public DiscountEvent(LocalDateTime start, LocalDateTime end, University university, Integer discountRate, Boolean isActivate) {
         this.start = start;
         this.end = end;
         this.university = university;
         this.discountRate = discountRate;
+        this.isActivate = isActivate;
+    }
+
+    @Override
+    public EventRes toEventRes() {
+        return new DiscountEventRes(id, start, end, EventType.DISCOUNT, isActivate, discountRate);
     }
 }

--- a/src/main/java/comatching/comatching3/event/entity/Event.java
+++ b/src/main/java/comatching/comatching3/event/entity/Event.java
@@ -1,6 +1,8 @@
 package comatching.comatching3.event.entity;
 
 import comatching.comatching3.admin.entity.University;
+import comatching.comatching3.event.dto.res.EventRes;
+import comatching.comatching3.util.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -12,12 +14,12 @@ import java.time.LocalDateTime;
 @DiscriminatorColumn(name = "event_type")
 @Setter
 @Getter
-public abstract class Event {
+public abstract class Event extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "event_id")
-    private Long id;
+    protected Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "university_id")
@@ -26,4 +28,8 @@ public abstract class Event {
     protected LocalDateTime start;
 
     protected LocalDateTime end;
+
+    protected Boolean isActivate;
+
+    abstract EventRes toEventRes();
 }

--- a/src/main/java/comatching/comatching3/event/repository/EventRepository.java
+++ b/src/main/java/comatching/comatching3/event/repository/EventRepository.java
@@ -19,4 +19,13 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     @Query("SELECT e FROM Event e WHERE e.university = :university")
     List<Event> findEventsByUniversity(@Param("university") University university);
+
+//    @Query("SELECT e FROM  Event e WHERE e.university = :university AND Now() >= :startTime AND Now() <= :endTime")
+//    Event findEventByUniversityBetween(@Param("university") University university,
+//                                       @Param("startTime") LocalDateTime start,
+//                                       @Param("endTime") LocalDateTime end);
+
+    @Query("SELECT e FROM Event e WHERE e.university = :university AND CURRENT_TIMESTAMP BETWEEN e.start AND e.end")
+    List<Event> findOngoingEventsByUniversity(@Param("university") University university);
+
 }

--- a/src/main/java/comatching/comatching3/event/service/AdminEventService.java
+++ b/src/main/java/comatching/comatching3/event/service/AdminEventService.java
@@ -44,6 +44,7 @@ public class AdminEventService {
         DiscountEvent discountEvent = DiscountEvent.builder()
                 .start(req.getStart())
                 .end(req.getEnd())
+                .isActivate(false)
                 .university(admin.getUniversity())
                 .discountRate(req.getDiscountRate())
                 .build();

--- a/src/main/java/comatching/comatching3/event/service/AdminEventService.java
+++ b/src/main/java/comatching/comatching3/event/service/AdminEventService.java
@@ -1,9 +1,8 @@
 package comatching.comatching3.event.service;
 
 import comatching.comatching3.admin.entity.Admin;
-import comatching.comatching3.admin.enums.EventType;
 import comatching.comatching3.event.dto.req.DiscountEventRegisterReq;
-import comatching.comatching3.event.dto.res.DiscountEventRes;
+import comatching.comatching3.event.dto.res.EventRes;
 import comatching.comatching3.event.entity.DiscountEvent;
 import comatching.comatching3.event.entity.Event;
 import comatching.comatching3.event.repository.EventRepository;
@@ -65,6 +64,7 @@ public class AdminEventService {
         JobParameters jobParameters = new JobParametersBuilder()
                 .addLong("eventId", eventId)
                 .addLong("universityId", universityId)
+                .addLong("timestamp", System.currentTimeMillis())
                 .toJobParameters();
 
         try {
@@ -93,26 +93,19 @@ public class AdminEventService {
      * @return 현재 존재하는 event list
      */
     @Transactional
-    public List<DiscountEventRes> inquiryEvent() {
+    public List<EventRes> inquiryEvent() {
         List<Event> eventList = eventRepository.findEventsByUniversity(securityUtil.getAdminFromContext().getUniversity());
-        List<DiscountEventRes> response = new ArrayList<>();
+        List<EventRes> response = new ArrayList<>();
 
         if (eventList == null) {
             throw new BusinessException(ResponseCode.NO_EVENT);
         }
 
         for (Event event : eventList) {
-            DiscountEventRes discountEventRes = new DiscountEventRes();
-            discountEventRes.setEnd(event.getEnd());
-            discountEventRes.setStart(event.getStart());
-            discountEventRes.setEventId(discountEventRes.getEventId());
 
             //할인 이벤트
-            if (event instanceof DiscountEvent) {
-                discountEventRes.setEventType(EventType.DISCOUNT);
-                discountEventRes.setDiscountRate(((DiscountEvent) event).getDiscountRate());
-            }
-            response.add(discountEventRes);
+            if (event instanceof DiscountEvent) response.add(((DiscountEvent) event).toEventRes());
+
         }
 
         return response;

--- a/src/main/java/comatching/comatching3/event/service/EventUserService.java
+++ b/src/main/java/comatching/comatching3/event/service/EventUserService.java
@@ -63,8 +63,7 @@ public class EventUserService {
         List<EventRes> eventResList = new ArrayList<>();
         for (Event event : events) {
             if (event instanceof DiscountEvent) {
-                DiscountEvent discountEvent = (DiscountEvent) event;
-                eventResList.add(discountEvent.toEventRes());
+                eventResList.add(((DiscountEvent) event).toEventRes());
             }
         }
 

--- a/src/main/java/comatching/comatching3/event/service/EventUserService.java
+++ b/src/main/java/comatching/comatching3/event/service/EventUserService.java
@@ -1,5 +1,9 @@
 package comatching.comatching3.event.service;
 
+import comatching.comatching3.admin.entity.University;
+import comatching.comatching3.event.dto.res.EventRes;
+import comatching.comatching3.event.entity.DiscountEvent;
+import comatching.comatching3.event.entity.Event;
 import comatching.comatching3.event.entity.EventParticipation;
 import comatching.comatching3.event.repository.EventParticipationRepository;
 import comatching.comatching3.event.repository.EventRepository;
@@ -12,6 +16,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,7 +28,7 @@ public class EventUserService {
     private final SecurityUtil securityUtil;
 
     /**
-     * 현재 유저에가 이벤트에 참여하는 것을 업데이트
+     * 현재 유저가 이벤트에 참여하는 것을 업데이트
      *
      * @param eventId : 유저가 참여할 이벤트
      *                이벤트 참여 시간 지날경우) EVT-004
@@ -42,5 +48,26 @@ public class EventUserService {
         if (!eventParticipation.getParticipated()) {
             eventParticipation.participateEvent();
         }
+    }
+
+    /**
+     * 현재 학교에서 진행중이거나 진행 예정인 event 조회
+     *
+     * @return 위 조건을 만족하는 Event 응답 객체 리스트
+     */
+    @Transactional
+    public List<EventRes> inquiryOpenEvent() {
+        University userUniversity = securityUtil.getCurrentUsersEntity().getUniversity();
+        List<Event> events = eventRepository.findOngoingEventsByUniversity(userUniversity);
+
+        List<EventRes> eventResList = new ArrayList<>();
+        for (Event event : events) {
+            if (event instanceof DiscountEvent) {
+                DiscountEvent discountEvent = (DiscountEvent) event;
+                eventResList.add(discountEvent.toEventRes());
+            }
+        }
+
+        return eventResList;
     }
 }

--- a/src/main/java/comatching/comatching3/event/util/EventScheduleComponent.java
+++ b/src/main/java/comatching/comatching3/event/util/EventScheduleComponent.java
@@ -1,0 +1,38 @@
+package comatching.comatching3.event.util;
+
+import comatching.comatching3.event.entity.Event;
+import comatching.comatching3.event.repository.EventRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+@Component
+public class EventScheduleComponent {
+
+    private EventRepository eventRepository;
+
+
+    /**
+     * 10분 마다 등록된 event의 활성화/비활성화 여부 판단
+     */
+    @Scheduled(cron = "0 0/10 * * * *")
+    public void activeEvent() {
+        List<Event> events = eventRepository.findAll();
+
+        if (events == null || events.isEmpty()) return;
+
+        LocalDateTime now = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS);
+        for (Event event : events) {
+            if (event.getStart().truncatedTo(ChronoUnit.MINUTES).equals(now)) {
+                event.setIsActivate(true);
+            }
+
+            if (event.getEnd().truncatedTo(ChronoUnit.MINUTES).equals(now)) {
+                event.setIsActivate(false);
+            }
+        }
+    }
+}

--- a/src/main/java/comatching/comatching3/util/ResponseCode.java
+++ b/src/main/java/comatching/comatching3/util/ResponseCode.java
@@ -66,7 +66,8 @@ public enum ResponseCode {
     EVENT_PERIOD_DUPLICATE(400, "EVT-001", HttpStatus.BAD_REQUEST, "Event period is duplicated!"),
     NO_EVENT(200, "EVT-002", HttpStatus.OK, "No event exist"),
     CANT_PARTICIPATE(200, "EVT-003", HttpStatus.OK, "You can't participate event"),
-    EVENT_TIME_OVER(200, "EVT-004", HttpStatus.OK, "Event time over");
+    EVENT_TIME_OVER(200, "EVT-004", HttpStatus.OK, "Event time over"),
+    WRONG_EVENT_STATUS(400, "EVT-005", HttpStatus.BAD_REQUEST, "WRONG EVENT STATUS");
 
 
     private final Integer status;


### PR DESCRIPTION
### 개요
 - Event 종류의 확장성을 고려 상속 사용
 - Event 권한별 제약조건 반영 조회 기능 추가 
 - Event 활성화를 위한 스케줄링 컴포넌트 추가

## 주요 변경점 
 Event entity와 EventRes dto의 상속 관계 형성 
 -> `Event`, `EventRes`를 각 이벤트가 상속

 Event entity의 response dto 변환 추상 메서드 `toResponse()` 추가
 -> 기타 조회기능 작성시 간결한 변환 코드 작성 가능

Event 활성화를 위한 스케줄링 컴포넌트 추가

User, Admin의 event 조회 기능 추가