### PR TITLE
[fix] - ($Admin) Admin 이벤트, 공지사항 조회 오류 수정

### DIFF
--- a/src/main/java/comatching/comatching3/chat/domain/dto/ChatRoomInfoRes.java
+++ b/src/main/java/comatching/comatching3/chat/domain/dto/ChatRoomInfoRes.java
@@ -1,0 +1,10 @@
+package comatching.comatching3.chat.domain.dto;
+
+
+import comatching.comatching3.chat.domain.ChatRole;
+
+import java.util.List;
+
+public record ChatRoomInfoRes(Long roomId, ChatRole myRole, List<ChatMessageDto> messages, String pickerName,
+                              String pickedName) {
+}

--- a/src/main/java/comatching/comatching3/event/controller/AdminEventController.java
+++ b/src/main/java/comatching/comatching3/event/controller/AdminEventController.java
@@ -7,11 +7,9 @@ import comatching.comatching3.util.Response;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -27,7 +25,7 @@ public class AdminEventController {
      * @param req
      * @return
      */
-    @PostMapping("/admin/event/register/discount")
+    @PostMapping("/auth/admin/event/discount")
     public Response registerDiscountEvent(@Validated @RequestBody DiscountEventRegisterReq req) {
 
         adminEventService.registerDiscountEvent(req);
@@ -39,9 +37,18 @@ public class AdminEventController {
      *
      * @return
      */
-    @GetMapping("/admin/event/inquiry")
-    public Response<List<EventRes>> inquiryEvent() {
-        return Response.ok(adminEventService.inquiryEvent());
+    @GetMapping("/auth/admin/event")
+    public Response<List<EventRes>> inquiryEvent(@RequestParam String status) {
+
+        List<EventRes> response = new ArrayList<>();
+
+        if (status.equals("OPEN")) {
+            response = adminEventService.inquiryEvent();
+        } else if (status.equals("CLOSED")) {
+            response = adminEventService.inquiryClosedEvent();
+        }
+
+        return Response.ok(response);
     }
 
 }

--- a/src/main/java/comatching/comatching3/event/repository/EventRepository.java
+++ b/src/main/java/comatching/comatching3/event/repository/EventRepository.java
@@ -28,4 +28,6 @@ public interface EventRepository extends JpaRepository<Event, Long> {
     @Query("SELECT e FROM Event e WHERE e.university = :university AND CURRENT_TIMESTAMP BETWEEN e.start AND e.end")
     List<Event> findOngoingEventsByUniversity(@Param("university") University university);
 
+    @Query("SELECT e FROM Event e WHERE e.university = :university AND CURRENT_TIMESTAMP > e.end ")
+    List<Event> findCloseEventsByUniversity(@Param("university") University university);
 }

--- a/src/main/java/comatching/comatching3/event/service/AdminEventService.java
+++ b/src/main/java/comatching/comatching3/event/service/AdminEventService.java
@@ -111,4 +111,42 @@ public class AdminEventService {
         return response;
     }
 
+    @Transactional
+    public List<EventRes> inquiryOpenEvent() {
+        List<Event> eventList = eventRepository.findEventsByUniversity(securityUtil.getAdminFromContext().getUniversity());
+        List<EventRes> response = new ArrayList<>();
+
+        if (eventList == null) {
+            throw new BusinessException(ResponseCode.NO_EVENT);
+        }
+
+        for (Event event : eventList) {
+
+            //할인 이벤트
+            if (event instanceof DiscountEvent) response.add(((DiscountEvent) event).toEventRes());
+
+        }
+
+        return response;
+    }
+
+    @Transactional
+    public List<EventRes> inquiryClosedEvent() {
+        List<Event> eventList = eventRepository.findCloseEventsByUniversity(securityUtil.getAdminFromContext().getUniversity());
+        List<EventRes> response = new ArrayList<>();
+
+        if (eventList == null) {
+            throw new BusinessException(ResponseCode.NO_EVENT);
+        }
+
+        for (Event event : eventList) {
+
+            //할인 이벤트
+            if (event instanceof DiscountEvent) response.add(((DiscountEvent) event).toEventRes());
+
+        }
+
+        return response;
+    }
+
 }

--- a/src/main/java/comatching/comatching3/notice/controller/AdminNoticeController.java
+++ b/src/main/java/comatching/comatching3/notice/controller/AdminNoticeController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
@@ -34,15 +35,16 @@ public class AdminNoticeController {
     }
 
     @GetMapping
-    public Response getOpenNotice(@RequestParam String state) {
+    public Response<List<NoticeRes>> getOpenNotice(@RequestParam String state) {
 
+        List<NoticeRes> res = new ArrayList<>();
         if (state.equals("OPEN")) {
-            List<NoticeRes> res = adminNoticeService.getOpenNotices();
-            return Response.ok(res);
+            res = adminNoticeService.getOpenNotices();
+
         } else if (state.equals("HISTORY")) {
-            List<NoticeRes> res = adminNoticeService.getClosedNotices();
+            res = adminNoticeService.getClosedNotices();
         }
 
-        return Response.ok();
+        return Response.ok(res);
     }
 }


### PR DESCRIPTION
공지사항 없을때 빈배열로 응답 변경
이벤트 restful한 조회 api  변경
 - `/event/inquiry` -> `/event?status={$OPTION}`